### PR TITLE
Fix failing documentation tests

### DIFF
--- a/src/instruction/print_data.rs
+++ b/src/instruction/print_data.rs
@@ -40,9 +40,10 @@ impl PrintDataBuilder {
     /// Replacement strings are a simple pattern matching replacement, where all matching instances of `target` get replaces by `replacement`
     ///
     /// ```rust
+    /// # use escpos_rs::PrintDataBuilder;
     /// let print_data = PrintDataBuilder::new()
     ///     // Instances of "%name%" will get replaced with "Carlos"
-    ///     .add_replacement("%name%", "Carlos")
+    ///     .replacement("%name%", "Carlos")
     ///     .build();
     /// ```
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! Not ready for production (yet, but soon!). For printing, a libusb [Context](https://docs.rs/libusb/0.3.0/libusb/struct.Context.html) is required.
 //!
-//! ```rust
+//! ```rust,no_run
 //! use escpos_rs::{Printer, PrinterProfile};
 //! use libusb::{Context};
 //!
@@ -40,7 +40,7 @@
 //!
 //! Because of the usual applications for thermal printers, the [Instruction](crate::Instruction) structure has been implemented, which allows you to define a sort of __template__, that you can use to print multiple documents with __certain__ data customized for each print.
 //!
-//! ```rust
+//! ```rust,no_run
 //! use escpos_rs::{
 //!     Printer, PrintData, PrinterProfile,
 //!     Instruction, Justification, command::Font
@@ -80,12 +80,12 @@
 //!         .build();
 //!     // We send the instruction to the printer, along with the custom data
 //!     // for this particular print
-//!     match printer.instruction(&instruction, &print_data_1) {
+//!     match printer.instruction(&instruction, Some(&print_data_1)) {
 //!         Ok(_) => (), // "Hello, Carlos!" should've been printed.
 //!         Err(e) => println!("Error: {}", e)
 //!     }
 //!     // Now we print the second data
-//!     match printer.instruction(&instruction, &print_data_2) {
+//!     match printer.instruction(&instruction, Some(&print_data_2)) {
 //!         Ok(_) => (), // "Hello, John!" should've been printed.
 //!         Err(e) => println!("Error: {}", e)
 //!     }

--- a/src/printer/printer_profile.rs
+++ b/src/printer/printer_profile.rs
@@ -39,8 +39,9 @@ impl PrinterProfile {
     ///
     /// Equivalent to a call to [PrinterProfileBuilder](crate::PrinterProfileBuilder)'s [new](crate::PrinterProfileBuilder::new) function.
     /// ```rust
+    /// # use escpos_rs::PrinterProfile;
     /// // Creates a minimum data structure to connect to a printer
-    /// let printer_profile = PrinterProfile::builder().build();
+    /// let printer_profile = PrinterProfile::builder(0x0001, 0x0001).build();
     /// ```
     pub fn builder(vendor_id: u16, product_id: u16) -> PrinterProfileBuilder {
         PrinterProfileBuilder::new(vendor_id, product_id)
@@ -63,6 +64,7 @@ impl PrinterProfileBuilder {
     /// Creates a new [PrinterProfileBuilder](crate::PrinterProfileBuilder)
     ///
     /// ```rust
+    /// # use escpos_rs::PrinterProfileBuilder;
     /// // Creates a minimum (probably non-working) data structure to connect to a printer
     /// let printer_profile = PrinterProfileBuilder::new(0x0001, 0x0001).build();
     /// ```
@@ -82,6 +84,7 @@ impl PrinterProfileBuilder {
     /// Sets the usb endpoint to which the data will be written.
     ///
     /// ```rust
+    /// # use escpos_rs::PrinterProfileBuilder;
     /// // Creates the printer details with the endpoint 0x02
     /// let printer_profile = PrinterProfileBuilder::new(0x0001, 0x0001)
     ///     .with_endpoint(0x02)
@@ -96,6 +99,7 @@ impl PrinterProfileBuilder {
     ///
     /// Defaults to 384, usually for 58mm printers.
     /// ```rust
+    /// # use escpos_rs::PrinterProfileBuilder;
     /// let printer_profile = PrinterProfileBuilder::new(0x0001, 0x0001)
     ///     .with_width(384)
     ///     .build();
@@ -109,6 +113,7 @@ impl PrinterProfileBuilder {
     ///
     /// This allows the justification, and proper word splitting to work. If you feel insecure about what value to use, the default font (FontA) usually has 32 characters of width for 58mm paper printers, and 48 for 80mm paper. You can also look for the specsheet, or do trial and error.
     /// ```rust
+    /// # use escpos_rs::{PrinterProfileBuilder, command::Font};
     /// let printer_profile = PrinterProfileBuilder::new(0x0001, 0x0001)
     ///     .with_font_width(Font::FontA, 32)
     ///     .build();
@@ -122,6 +127,7 @@ impl PrinterProfileBuilder {
     ///
     /// USB devices might fail to write to the bulk endpoint. In such a case, a timeout must be provided to know when to stop waiting for the buffer to flush to the printer. The default value is 2 seconds.
     /// ```rust
+    /// # use escpos_rs::PrinterProfileBuilder;
     /// let printer_profile = PrinterProfileBuilder::new(0x0001, 0x0001)
     ///     .with_timeout(std::time::Duration::from_secs(3))
     ///     .build();
@@ -134,6 +140,7 @@ impl PrinterProfileBuilder {
     /// Build the `PrinterProfile` that lies beneath the builder
     ///
     /// ```rust
+    /// # use escpos_rs::PrinterProfileBuilder;
     /// let printer_profile = PrinterProfileBuilder::new(0x0001, 0x0001).build();
     /// ```
     pub fn build(self) -> PrinterProfile {

--- a/src/printer/usb_printer.rs
+++ b/src/printer/usb_printer.rs
@@ -18,8 +18,8 @@ use super::{PrinterProfile, PrinterModel};
 /// Main escpos-rs structure
 ///
 /// The printer represents the thermal printer connected to the computer.
-/// ```rust
-/// use escpos_rs::{Printer};
+/// ```rust,no_run
+/// use escpos_rs::{Printer, PrinterModel};
 /// use libusb::{Context};
 ///
 /// fn main() {
@@ -143,7 +143,7 @@ impl<'a> Printer<'a> {
     ///
     /// You can pass optional printer data to the printer to fill in the dynamic parts of the instruction.
     pub fn instruction(&self, instruction: &Instruction, print_data: Option<&PrintData>) -> Result<(), Error> {
-        let content = instruction.to_vec(&self.printer_profile, print_data).unwrap();
+        let content = instruction.to_vec(&self.printer_profile, print_data)?;
         self.raw(&content)
     }
     
@@ -196,9 +196,14 @@ impl<'a> Printer<'a> {
     /// Sends raw information to the printer
     ///
     /// As simple as it sounds
-    /// ```rust
-    /// let bytes = vec![0x01, 0x02];
-    /// printer.raw(bytes)
+    /// ```rust,no_run
+    /// # use libusb::Context;
+    /// # use escpos_rs::{Printer,PrinterProfile};
+    /// # let context = Context::new().unwrap();
+    /// # let printer_profile = PrinterProfile::builder(0x0001, 0x0001).build();
+    /// # let printer = Printer::with_context(&context, printer_profile).unwrap().unwrap();
+    /// printer.raw(&[0x01, 0x02])?;
+    /// # Ok::<(), escpos_rs::Error>(())
     /// ```
     pub fn raw<A: AsRef<[u8]>>(&self, bytes: A) -> Result<(), Error> {
         self.dh.write_bulk(


### PR DESCRIPTION
- Fix syntax errors/missing imports
- Stop tests that deal with a printer from running since they will just panic

This is a separate PR from the other since it in essence is a different change. By seperating the changes into multiple PRs you can individually accept one or the other or both. The rustdoc documentation is a good place to look for information on doctests. (https://doc.rust-lang.org/rustdoc/documentation-tests.html).

I would suggest setting up running these tests (run whenever you run `cargo test`) on GitHub Actions or some other CI service so that it is sure to be run on all of your code when you make changes